### PR TITLE
update go modules path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module spannerplandiff
+module github.com/apstndb/spannerplandiff
 
 go 1.16
 


### PR DESCRIPTION
I failed go install, so I fixed it according to the error message.

```
go install github.com/apstndb/spannerplandiff@latest
go install github.com/apstndb/spannerplandiff@latest: github.com/apstndb/spannerplandiff@none updating to
	github.com/apstndb/spannerplandiff@v0.0.0-20210713041058-1eaf89853d11: parsing go.mod:
	module declares its path as: spannerplandiff
	        but was required as: github.com/apstndb/spannerplandiff
```